### PR TITLE
Fix for RAT Build Exception for HDP-Kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ ext {
 
 apply from: file('wrapper.gradle')
 apply from: file('scala.gradle')
-apply from: file('gradle/rat.gradle')
 
 if (new File('.git').exists()) {
   apply from: file('gradle/rat.gradle')


### PR DESCRIPTION
Hi,

For RAT build exception, Here Kafka is using "gradle" tool which uses "build.gradle" to build , have removed  code i.e. <apply from: file('gradle/rat.gradle')>  as already there is check for if ".git" file exist than add below code:
apply from: file('gradle/rat.gradle')

This is merging issue as latest release of "https://github.com/apache/kafka" contains this fix.
