### PR TITLE
Fix for Test failure for SslTransportLayerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -68,8 +68,8 @@ public class SslTransportLayerTest {
     @Before
     public void setup() throws Exception {
         // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
-        serverCertStores = new CertStores(true);
-        clientCertStores = new CertStores(false);
+        serverCertStores = new CertStores(true, "localhost");
+        clientCertStores = new CertStores(false, "localhost");
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
@@ -103,19 +103,21 @@ public class SslTransportLayerTest {
     }
     
     /**
-     * Tests that server certificate with invalid IP address is not accepted by
-     * a client that validates server endpoint. Certificate uses "localhost" as
-     * common name, test uses host IP to trigger endpoint validation failure.
+     * Tests that server certificate with invalid host name is not accepted by
+     * a client that validates server endpoint. Server certificate uses
+     * wrong hostname as common name to trigger endpoint validation failure.
      */
     @Test
     public void testInvalidEndpointIdentification() throws Exception {
         String node = "0";
-        String serverHost = InetAddress.getLocalHost().getHostAddress();
-        server = new SslEchoServer(sslServerConfigs, serverHost);
-        server.start();
+        serverCertStores = new CertStores(true, "notahost");
+        clientCertStores = new CertStores(false, "localhost");
+        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
+        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+        createEchoServer(sslServerConfigs);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         createSelector(sslClientConfigs);
-        InetSocketAddress addr = new InetSocketAddress(serverHost, server.port);
+        InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
         waitForChannelClose(node);
@@ -459,11 +461,11 @@ public class SslTransportLayerTest {
         
         Map<String, Object> sslConfig;
         
-        CertStores(boolean server) throws Exception {
+        CertStores(boolean server, String host) throws Exception {
             String name = server ? "server" : "client";
             Mode mode = server ? Mode.SERVER : Mode.CLIENT;
             File truststoreFile = File.createTempFile(name + "TS", ".jks");
-            sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name);
+            sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, host);
             if (server)
                 sslConfig.put(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, Class.forName(SslConfigs.DEFAULT_PRINCIPAL_BUILDER_CLASS));
         }

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -205,6 +205,11 @@ public class TestSslUtils {
 
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore, Mode mode, File trustStoreFile, String certAlias)
         throws IOException, GeneralSecurityException {
+        return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, "localhost");
+    }
+
+    public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore, Mode mode, File trustStoreFile, String certAlias, String host)
+        throws IOException, GeneralSecurityException {
         Map<String, X509Certificate> certs = new HashMap<String, X509Certificate>();
         File keyStoreFile;
         Password password;
@@ -219,13 +224,13 @@ public class TestSslUtils {
         if (useClientCert) {
             keyStoreFile = File.createTempFile("clientKS", ".jks");
             KeyPair cKP = generateKeyPair("RSA");
-            X509Certificate cCert = generateCertificate("CN=localhost, O=client", cKP, 30, "SHA1withRSA");
+            X509Certificate cCert = generateCertificate("CN=" + host + ", O=client", cKP, 30, "SHA1withRSA");
             createKeyStore(keyStoreFile.getPath(), password, "client", cKP.getPrivate(), cCert);
             certs.put(certAlias, cCert);
         } else {
             keyStoreFile = File.createTempFile("serverKS", ".jks");
             KeyPair sKP = generateKeyPair("RSA");
-            X509Certificate sCert = generateCertificate("CN=localhost, O=server", sKP, 30,
+            X509Certificate sCert = generateCertificate("CN=" + host + ", O=server", sKP, 30,
                                                         "SHA1withRSA");
             createKeyStore(keyStoreFile.getPath(), password, password, "server", sKP.getPrivate(), sCert);
             certs.put(certAlias, sCert);


### PR DESCRIPTION
Have fixed for Test error below:
org.apache.kafka.common.network.SslTransportLayerTest > testInvalidEndpointIdentification FAILED
java.lang.AssertionError

It is referenced from "https://patch-diff.githubusercontent.com/raw/apache/kafka/pull/546.patch"
