### PR TITLE
Fix for Build failure ImportError for HDP-Kafka

### DIFF
--- a/build-kafka-ppc64le.sh
+++ b/build-kafka-ppc64le.sh
@@ -17,3 +17,4 @@ set -ex
 
 export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -XX:PermSize=1024m -XX:MaxPermSize=1024m"
 ./gradlew clean releaseTarGz -x signArchives
+./gradlew build -Dcheckstyle.config.path=`pwd`

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -67,7 +67,7 @@
 
     <!-- dependencies -->
     <module name="ImportControl">
-      <property name="file" value="${basedir}/checkstyle/import-control.xml"/>
+      <property name="file" value="${checkstyle.config.path}/checkstyle/import-control.xml"/>
     </module>
 
     <!-- whitespace -->


### PR DESCRIPTION
Hi,

I could fix below build error for "HDP-Kafka" for RHEL 7.2 ppc64le using jdk 1.7 using gradle tool:

Error:Execution failed for task ':clients:checkstyleMain'.
Unable to create a Checker: cannot initialize module TreeWalker

Cannot set property ‘file’ in module

Have done code change in "checkstyle" file and build script
